### PR TITLE
feat: add optional LLM summarization

### DIFF
--- a/src/components/SearchInterface.tsx
+++ b/src/components/SearchInterface.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 interface SearchSettings {
   strict: boolean;
   resultCount: number;
+  useLlm: boolean;
 }
 
 interface SearchInterfaceProps {
@@ -25,7 +26,8 @@ export function SearchInterface({ onSearch, onReindex, isLoading, isReindexing }
   const [query, setQuery] = useState("");
   const [settings, setSettings] = useState<SearchSettings>({
     strict: true,
-    resultCount: 8
+    resultCount: 8,
+    useLlm: false
   });
   const [showSettings, setShowSettings] = useState(false);
   const { toast } = useToast();
@@ -139,6 +141,24 @@ export function SearchInterface({ onSearch, onReindex, isLoading, isReindexing }
                 </div>
               </div>
 
+              <div className="flex items-center space-x-3">
+                <Switch
+                  id="llm-summary"
+                  checked={settings.useLlm}
+                  onCheckedChange={(checked) =>
+                    setSettings(prev => ({ ...prev, useLlm: checked }))
+                  }
+                />
+                <div className="space-y-1">
+                  <Label htmlFor="llm-summary" className="text-sm font-medium">
+                    LLM සාරාංශය
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    OpenAI LLM භාවිතයෙන් සාරාංශයක්
+                  </p>
+                </div>
+              </div>
+
               <div className="space-y-2">
                 <Label className="text-sm font-medium">ප්‍රතිඵල ගණන</Label>
                 <Select
@@ -167,6 +187,9 @@ export function SearchInterface({ onSearch, onReindex, isLoading, isReindexing }
               </Badge>
               <Badge variant="outline" className="border-dharma/30 text-dharma">
                 ප්‍රතිඵල: {settings.resultCount}
+              </Badge>
+              <Badge variant="outline" className="border-saffron/30 text-saffron">
+                LLM: {settings.useLlm ? "සක්‍රිය" : "අක්‍රිය"}
               </Badge>
             </div>
           </div>

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -5,6 +5,7 @@ import { SearchResult, SearchSnippet } from '@/lib/supabase';
 interface SearchSettings {
   strict: boolean;
   resultCount: number;
+  useLlm: boolean;
 }
 
 export function useSearch() {
@@ -16,7 +17,8 @@ export function useSearch() {
     try {
       const searchResult = await searchDocuments(query, {
         limit: settings.resultCount,
-        strict: settings.strict
+        strict: settings.strict,
+        useLlm: settings.useLlm
       });
       setResult(searchResult);
     } catch (error) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,6 +13,7 @@ import { useToast } from "@/hooks/use-toast";
 interface SearchSettings {
   strict: boolean;
   resultCount: number;
+  useLlm: boolean;
 }
 
 export default function Index() {


### PR DESCRIPTION
## Summary
- add generateAnswer helper calling Supabase edge LLM with strict fallback
- replace strict answer calls and plumb useLlm option through search
- expose LLM summarization toggle in search interface

## Testing
- `npm test`
- `npm run lint` *(fails: react-refresh and eslint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a76686bcd483239f871d29fd05d116