### PR TITLE
feat: highlight Sinhala search terms

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, ReactNode } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -30,6 +30,20 @@ interface SearchResultsProps {
 export function SearchResults({ result, isLoading, onExpandContext }: SearchResultsProps) {
   const [expandedSnippets, setExpandedSnippets] = useState<Set<string>>(new Set());
   const [loadingContext, setLoadingContext] = useState<Set<string>>(new Set());
+
+  const highlightText = (text: string, query: string): ReactNode => {
+    if (!query) return text;
+    const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const terms = query
+      .split(/\s+/)
+      .filter(Boolean)
+      .map(escapeRegExp);
+    if (terms.length === 0) return text;
+    const pattern = new RegExp(`(${terms.join("|")})`, "gu");
+    return text.split(pattern).map((part, i) =>
+      i % 2 === 1 ? <mark key={i}>{part}</mark> : part
+    );
+  };
 
   if (isLoading) {
     return (
@@ -173,10 +187,12 @@ export function SearchResults({ result, isLoading, onExpandContext }: SearchResu
                     <div className="space-y-3">
                       <div className="prose prose-sm max-w-none">
                         <p className="text-foreground leading-relaxed">
-                          {isExpanded && snippet.expandedText 
-                            ? snippet.expandedText 
-                            : snippet.text
-                          }
+                          {highlightText(
+                            isExpanded && snippet.expandedText
+                              ? snippet.expandedText
+                              : snippet.text,
+                            result.query
+                          )}
                         </p>
                       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -140,3 +140,9 @@ All colors MUST be HSL.
     -webkit-font-smoothing: antialiased;
   }
 }
+
+@layer components {
+  mark {
+    @apply bg-saffron-light/40 dark:bg-saffron-dark/60 text-foreground rounded px-1;
+  }
+}


### PR DESCRIPTION
## Summary
- highlight Sinhala query matches in results with `<mark>`
- add Tailwind component style for highlighted terms

## Testing
- `npm test`
- `npm run lint` *(fails: existing warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a769a54ab08323b80cbd16e207e815